### PR TITLE
chore: export linked list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './LinkedList';
 export * from './Map';
 export * from './Set';
 export * from './Queue';


### PR DESCRIPTION
This PR would export the `LinkedList` in the main file.

I noticed it was missing at the time of the build.