### PR TITLE
perf(husky): prepare script and command 

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npm run check

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "npm run check && rimraf dist && NODE_ENV=production node esbuild.js && npm run ts-types",
     "prettier": "prettier --write ./src",
     "lint": "eslint ./src --ext .ts",
+    "prepare": "husky install",
     "dev": "jest --watch",
     "test": "jest --no-cache",
     "coverage": "jest --coverage",


### PR DESCRIPTION
This PR adds the `prepare` script that runs before publishing and after npm install so you can install hooks in your repo automatically.

Furthermore, I've changed the `npm lint-staged` with `npm run check` that runs the formatter/linter and test before the commit.
